### PR TITLE
baseURL 변경

### DIFF
--- a/src/hooks/useAxios.jsx
+++ b/src/hooks/useAxios.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 
-axios.defaults.baseURL = "http://146.56.183.55:5050";
-// axios.defaults.baseURL = "https://mandarin.api.weniv.co.kr";
+// axios.defaults.baseURL = "http://146.56.183.55:5050";
+axios.defaults.baseURL = "https://mandarin.api.weniv.co.kr";
 axios.defaults.headers["content-Type"] = "application/json";
 
 axios.interceptors.request.use(


### PR DESCRIPTION
예제페이지 api 호출 주소로 사용하다가 어느정도 완성 후 실습  api 주소로 변경합니다.

- [x] 신규 기능 추가 :
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [x] 기타 : 

### 변경사항 및 이유

- 예제페이지 주소로 사용하다 어느정도 완성 후 실습페이지 API 주소로 변경했습니다.

