### PR TITLE
:sparkles: ProfilePost 부분 구현 , 기타 수정사항 정리

### DIFF
--- a/src/components/home/Post.jsx
+++ b/src/components/home/Post.jsx
@@ -93,7 +93,7 @@ const Post = ({ datas }) => {
 
     return (
         <>
-            {datas.map((v, i) => {
+            {datas?.map((v, i) => {
                 const PostImgSrc = v.image.split(",");
                 console.log(PostImgSrc);
                 return (
@@ -122,7 +122,7 @@ const Post = ({ datas }) => {
                                     <LIkeCommentIcon
                                         src={
                                             process.env.PUBLIC_URL +
-                                            "./icons/icon-heart.png"
+                                            "/icons/icon-heart.png"
                                         }
                                     />
                                     <LikeCommentCounter>
@@ -133,7 +133,7 @@ const Post = ({ datas }) => {
                                     <LIkeCommentIcon
                                         src={
                                             process.env.PUBLIC_URL +
-                                            "./icons/icon-message-circle.png"
+                                            "/icons/icon-message-circle.png"
                                         }
                                     />
                                     <LikeCommentCounter>

--- a/src/components/profile/PostAlbum.jsx
+++ b/src/components/profile/PostAlbum.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+const AlbumPostWrap = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    max-width: 390px;
+`;
+const PostList = styled.ul`
+    display: grid;
+    grid-template-columns: 114px 114px 114px;
+    gap: 8px;
+`;
+const Postitem = styled.li`
+    max-height: 114px;
+    min-height: 114px;
+`;
+const PostImg = styled.img`
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: all 0.4s;
+    border-radius: 5px;
+`;
+const PostLink = styled(Link)`
+    width: 100%;
+    height: 100%;
+`;
+// datas 값을 받아와서 처리하는게 아니라 accountname 값을 받아서 post 에서 데이터요청을 해서 처리하는게 맞는지 ?
+const Post = ({ datas }) => {
+    const [imgNum, setImgNum] = useState("0");
+    // 이미지가 여러개일 경우 추가하려고 작성(미완성)
+    useEffect(() => {
+        console.log(datas);
+    }, [datas]);
+
+    return (
+        <AlbumPostWrap>
+            <PostList>
+                {datas
+                    ?.filter((i) => i.image.length !== 0)
+                    .map((v, i) => {
+                        const PostImgSrc = v.image.split(",");
+                        console.log(v.id);
+                        console.log(PostImgSrc);
+                        return (
+                            <Postitem key={i}>
+                                <PostLink to={`/postdetail/:${v.id}`}>
+                                    <PostImg src={PostImgSrc[imgNum]} />
+                                </PostLink>
+                            </Postitem>
+                        );
+                    })}
+            </PostList>
+        </AlbumPostWrap>
+    );
+};
+
+export default Post;

--- a/src/components/profile/Profile.jsx
+++ b/src/components/profile/Profile.jsx
@@ -14,10 +14,8 @@ import { Link } from "react-router-dom";
 import LoadingPage from "../../pages/LoadingPage";
 
 const Wrapper = styled.div`
-    max-width: 390px;
     padding: 30px 16px 26px;
     position: relative;
-    box-sizing: border-box;
     margin: 0 auto;
 `;
 
@@ -100,9 +98,7 @@ const FollowingLink = styled(FollowLink)`
 
 function Profile(props) {
     const { profileAccountName, myAccountName } = props;
-
     const { error, profile, isPending } = useProfile(profileAccountName);
-
     const [modal, setModal] = useState(false);
     const [alertModal, setAlertModal] = useState(false);
 
@@ -139,11 +135,7 @@ function Profile(props) {
                             <>
                                 <TopNav
                                     leftChild={<BackButton />}
-                                    rightChild={
-                                        <ModalButton
-                                            onClick={() => setModal(!modal)}
-                                        />
-                                    }
+                                    rightChild={<ModalButton onClick={() => setModal(!modal)} />}
                                 />
                                 <Wrapper>
                                     <StyledProfileImg imgSrc={profile.image} />
@@ -157,9 +149,7 @@ function Profile(props) {
                                     )}
 
                                     <FollowerWrapper>
-                                        <FollowLink
-                                            to={`/follow/${profileAccountName}/follower`}
-                                        >
+                                        <FollowLink to={`/follow/${profileAccountName}/follower`}>
                                             {profile.followerCount}
                                         </FollowLink>
                                         <StyledSpan>followers</StyledSpan>

--- a/src/components/profile/ProfilePost.jsx
+++ b/src/components/profile/ProfilePost.jsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from "react";
+import Post from "../home/Post";
+import PostAlbum from "./PostAlbum";
+import { useAxios } from "../../hooks/useAxios";
+import styled from "styled-components";
+import { useLocation } from "react-router-dom";
+
+const PostTypeControlDiv = styled.div`
+    width: 100%;
+    border-top: 1px solid #727272;
+    border-bottom: 0.5px solid #727272;
+    padding: 10px 16px;
+    margin-bottom: 16px;
+    display: flex;
+    justify-content: center;
+`;
+const PostTypeControlWrap = styled.div`
+    max-width: 390px;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+`;
+const PostTypeControlIcon = styled.img`
+    width: 26px;
+    height: 26px;
+    cursor: pointer;
+`;
+
+const ProfilePostWrap = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+`;
+
+const ProfilePost = () => {
+    const [btnState, setBtnState] = useState("list");
+    const [accountName, setAccountName] = useState("");
+    const location = useLocation();
+
+    function toggleBtnState() {
+        btnState === "list" ? setBtnState("album") : setBtnState("list");
+    }
+
+    let getUserPost = {
+        url: `/post/${accountName}/userpost`,
+        method: "GET",
+    };
+
+    const { response, callRefetch } = useAxios(getUserPost);
+
+    useEffect(() => {
+        console.log(location);
+        let data = location?.state;
+        callRefetch();
+        if (data) {
+            setAccountName(data);
+        } else {
+            setAccountName(localStorage.getItem("accountname"));
+        }
+        console.log(response?.data.post);
+    }, [location]);
+    return (
+        <>
+            <PostTypeControlDiv>
+                <PostTypeControlWrap>
+                    <button type="button" onClick={toggleBtnState}>
+                        <PostTypeControlIcon
+                            src={
+                                btnState === "list"
+                                    ? process.env.PUBLIC_URL + "/icons/icon-post-list-on.png"
+                                    : process.env.PUBLIC_URL + "/icons/icon-post-list-off.png"
+                            }
+                        />
+                    </button>
+                    <button type="button" onClick={toggleBtnState}>
+                        <PostTypeControlIcon
+                            src={
+                                btnState === "list"
+                                    ? process.env.PUBLIC_URL + "/icons/icon-post-album-off.png"
+                                    : process.env.PUBLIC_URL + "/icons/icon-post-album-on.png"
+                            }
+                        />
+                    </button>
+                </PostTypeControlWrap>
+            </PostTypeControlDiv>
+            <ProfilePostWrap>
+                {btnState === "list" ? (
+                    <Post datas={response?.data.post} />
+                ) : (
+                    <PostAlbum datas={response?.data.post} />
+                )}
+            </ProfilePostWrap>
+        </>
+    );
+};
+
+export default ProfilePost;

--- a/src/components/search/SearchUserItem.jsx
+++ b/src/components/search/SearchUserItem.jsx
@@ -47,7 +47,7 @@ function SearchUserItem({ profileImg, userName, userId, imgSize }) {
     const defaultImgSrc =
         process.env.PUBLIC_URL + "/images/LegoDefaultImage.png";
     return (
-        <UserAnchor to={`/profile/${userId}`}>
+        <UserAnchor to={`/myprofile/${userId}`} state={userId}>
             <UserProfileImg
                 src={profileImg === null ? defaultImgSrc : profileImg}
                 imgSize={imgSize}

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,16 +1,23 @@
-import React, { useEffect } from "react";
+import React from "react";
 import Profile from "../components/profile/Profile";
 import { Link, useParams } from "react-router-dom";
 import { useInfo } from "../hooks/useInfo";
 import { useAuthContext } from "../hooks/useAuthContext";
-
+import ProfilePost from "../components/profile/ProfilePost";
+import styled from "styled-components";
+const ProfileMainWrap = styled.div`
+    min-width: 390px;
+    width: 100%;
+    height: calc(100% - 61px);
+    overflow-y: auto;
+    overflow-x: hidden;
+`;
 function ProfilePage() {
     // 쿼리로 넘어오는거
     // 자기프로필이면 accountname이 undefined임
 
     console.log("프로필페이지 렌더링");
     const { accountname } = useParams();
-
     const { user } = useAuthContext();
     console.log("user : ", user);
 
@@ -27,7 +34,7 @@ function ProfilePage() {
     }
 
     return (
-        <>
+        <ProfileMainWrap>
             <Profile
                 // 프로필에서 띄워줄 accountname
                 profileAccountName={profileAccountName}
@@ -35,8 +42,8 @@ function ProfilePage() {
                 myAccountName={myAccountName}
             />
             {/* 재모님 : 상품리스트 // accountname만 필요함 */}
-            {/* 원형님 :  */}
-        </>
+            <ProfilePost />
+        </ProfileMainWrap>
     );
 }
 


### PR DESCRIPTION
Profile 페이지에서 아래의 사용자게시글 부분을 구현, SearchUserItem 에서 클릭 시 이동하는 경로 수정, Profile 페이지 전체 스타일컴포넌트 추가

- [x] 신규 기능 추가 :  
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

- Profile 페이지의 하단 게시글 부분을 구현했습니다. 기본으로 리스트형이 나오고 앨범형은 사진만(사진이 없는 게시글은 없어집니다) 나오도록 구현했습니다. 
- ProfilePage 에 ProfilePost 컴포넌트를 추가하고 앨범형식은 PostAlbum 컴포넌트를 따로 만들어서 조건부 렌더링 처리 했습니다.
- 붙이고 보니 스크롤이 안돼서 페이지 전체를 감싸주는 ProfileMainWrap 스타일컴포넌트를 추가했습니다.
- SearchUserItem 에서 누르면 이동하는 경로 수정했습니다. /profile -> /myprofile

### 작업 후 기대 동작(스크린샷)

d
![CleanShot 2022-07-25 at 01 15 01](https://user-images.githubusercontent.com/54429762/180656318-bcd8fe4c-ee71-43ea-a34c-0b776ffb366d.gif)


### PR 특이 사항

- 특이 사항
1. ProfilePage 에서 넘기는 profileAccountName 을 사용해서도 구현해놨는데 새로고침하면 user 데이터가 없어지면서 if(user) 처리가 되지않고 undefined 를 넘겨주기 때문에 렌더링이 안되는 현상이 있어서 일단 ProfilePost 에서 값을 따로 처리하는 방법으로 push 했습니다. 어떻게 해결하면 좋을까요 ? 
제가 처리한 방법은 로그인하면 토큰값으로 accountname 을 설정해주니 기본 프로필 가져오는 부분은 토큰에 저장된 값을 이용하는 방식으로 했습니다.

3. 합치고보니 예제페이지에서 scroll 부분이 전체적으로 되어있어서 스크롤하면 프로필부분이 고정된게 아니라 올라가는 형식이라 ProfilePage에 스타일컴포넌트 하나 추가해서 감싸주었습니다.



### 어떤 부분에 리뷰어가 집중하면 좋을까요?

충돌날수있는 부분이 좀 있어서 모든 팀원이 보면 머지 하겠습니다.
