### PR TITLE
:ambulance: PostAlbum 링크 이동 오타로 안되는 오류 수정

### DIFF
--- a/src/components/post/postAlbum/PostAlbum.jsx
+++ b/src/components/post/postAlbum/PostAlbum.jsx
@@ -17,7 +17,7 @@ const ProfilePostAlbum = ({ datas }) => {
                         const PostImgSrc = v.image.split(",");
                         return (
                             <PostItem key={i}>
-                                <PostLink to={`/postdetail/:${v.id}`}>
+                                <PostLink to={`/postdetail/${v?.id}`}>
                                     <PostImg
                                         src={PostImgSrc[imgNum]}
                                         alt={v.image.split(/^(https?)\/\//)}


### PR DESCRIPTION
경로에 : 을 모르고 집어넣어서 작동이 안됐음

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : PostAlbum -> PostDetail 이동 오류
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유
경로에 postid 앞에 : 을 집어넣어서 작동이 안됐음


